### PR TITLE
feat: Implement homepage first screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -439,4 +439,33 @@
   .glass-card {
     @apply bg-card/90 backdrop-blur-md border border-border shadow-none;
   }
+
+  /* ── Hide scrollbar ─────────────────────────────── */
+  .scrollbar-none {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════
+   Animations
+   ═══════════════════════════════════════════════════════ */
+@keyframes ticker-scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+.ticker-track {
+  animation: ticker-scroll 30s linear infinite;
+}
+
+.ticker-track:hover {
+  animation-play-state: paused;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,165 +1,25 @@
+import { Navbar } from "@/components/layout/Navbar"
+import { TrendingTicker } from "@/components/layout/TrendingTicker"
+import { Footer } from "@/components/layout/Footer"
+import { CategoryTabs } from "@/components/home/CategoryTabs"
+import { FeaturedHero } from "@/components/home/FeaturedHero"
+import { LiveSports } from "@/components/home/LiveSports"
+import { AllMarkets } from "@/components/home/AllMarkets"
+
 export default function Home() {
     return (
-        <main className="container-app min-h-screen">
-            {/* Hero Section */}
-            <section className="py-12 space-y-3">
-                <h1 className="text-hero text-foreground">Hello World</h1>
-                <p className="text-body-lg text-muted-foreground">
-                    Precast — The World&apos;s Largest Prediction Market
-                </p>
-            </section>
+        <>
+            <Navbar />
+            <TrendingTicker />
 
-            {/* Typography Scale */}
-            <section className="py-8 space-y-6 border-t border-border">
-                <h2 className="text-heading-2-xl text-foreground">Typography Scale</h2>
+            <main className="container-app space-y-8 py-6">
+                <CategoryTabs />
+                <FeaturedHero />
+                <LiveSports />
+                <AllMarkets />
+            </main>
 
-                <div className="space-y-4">
-                    <div className="space-y-1">
-                        <span className="text-caption">Hero — Inter Bold 36/40</span>
-                        <p className="text-hero">The quick brown fox</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Heading 2 XL — Inter Bold 24/32</span>
-                        <p className="text-heading-2-xl">The quick brown fox</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Heading 2 LG — Inter Bold 20/28</span>
-                        <p className="text-heading-2-lg">The quick brown fox</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Heading 1 — Inter Bold 18/28</span>
-                        <p className="text-heading-1">The quick brown fox</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Heading 3 — Inter Bold 14/20</span>
-                        <p className="text-heading-3">The quick brown fox</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Body LG — Inter Medium 16/24</span>
-                        <p className="text-body-lg">The quick brown fox jumps over the lazy dog</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Body — Inter Regular 14/20</span>
-                        <p className="text-body">The quick brown fox jumps over the lazy dog</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Label — Inter Medium 14/14</span>
-                        <p className="text-label">Market Category</p>
-                    </div>
-                    <div className="space-y-1">
-                        <span className="text-caption">Caption — Inter Medium 12/16</span>
-                        <p className="text-caption">$15.7M Vol · 15,678 traders</p>
-                    </div>
-                </div>
-            </section>
-
-            {/* Color Swatches */}
-            <section className="py-8 space-y-6 border-t border-border">
-                <h2 className="text-heading-2-xl text-foreground">Color Palette</h2>
-
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-                    {[
-                        { name: "Background", var: "bg-background", hex: "#000A00" },
-                        { name: "Card", var: "bg-card", hex: "#141F14" },
-                        { name: "Primary", var: "bg-primary", hex: "#1E993B" },
-                        { name: "Destructive", var: "bg-destructive", hex: "#EF4343" },
-                        { name: "Warning", var: "bg-warning", hex: "#EAE243" },
-                        { name: "Secondary", var: "bg-secondary", hex: "#1E2A1E" },
-                        { name: "Muted", var: "bg-muted", hex: "#0D160D" },
-                        { name: "Border", var: "bg-border", hex: "#1A2E1A" },
-                        { name: "Info", var: "bg-info", hex: "#6495ED" },
-                    ].map((color) => (
-                        <div key={color.name} className="space-y-2">
-                            <div className={`h-16 rounded-xl ${color.var} border border-border`} />
-                            <div>
-                                <p className="text-heading-3 text-foreground">{color.name}</p>
-                                <p className="text-caption">{color.hex}</p>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </section>
-
-            {/* Button Styles */}
-            <section className="py-8 space-y-6 border-t border-border">
-                <h2 className="text-heading-2-xl text-foreground">Buttons</h2>
-
-                <div className="flex flex-wrap gap-4">
-                    <button className="inline-flex items-center px-5 py-2.5 rounded-lg bg-primary text-primary-foreground text-btn-lg transition-opacity hover:opacity-90">
-                        Buy Yes
-                    </button>
-                    <button className="inline-flex items-center px-5 py-2.5 rounded-lg bg-destructive text-destructive-foreground text-btn-lg transition-opacity hover:opacity-90">
-                        Buy No
-                    </button>
-                    <button className="inline-flex items-center px-4 py-2 rounded-md bg-secondary text-secondary-foreground text-btn transition-opacity hover:opacity-90">
-                        Secondary
-                    </button>
-                    <button className="inline-flex items-center px-4 py-2 rounded-md border border-border text-muted-foreground text-btn transition-colors hover:text-foreground">
-                        Outline
-                    </button>
-                </div>
-
-                <div className="flex flex-wrap gap-3">
-                    <span className="inline-flex items-center px-3 py-1 rounded-md bg-primary/10 text-primary text-btn">
-                        Yes 45¢
-                    </span>
-                    <span className="inline-flex items-center px-3 py-1 rounded-md bg-destructive/10 text-destructive text-btn">
-                        No 55¢
-                    </span>
-                    <span className="inline-flex items-center px-3 py-1 rounded-md bg-warning/10 text-warning text-label">
-                        Featured
-                    </span>
-                </div>
-            </section>
-
-            {/* Spacing Scale */}
-            <section className="py-8 space-y-6 border-t border-border">
-                <h2 className="text-heading-2-xl text-foreground">Spacing Scale</h2>
-
-                <div className="space-y-2">
-                    {[4, 8, 12, 16, 20, 24, 32, 40, 48, 64].map((px) => (
-                        <div key={px} className="flex items-center gap-4">
-                            <span className="text-caption w-12 text-right">{px}px</span>
-                            <div
-                                className="h-3 rounded bg-primary/40"
-                                style={{ width: `${px * 3}px` }}
-                            />
-                        </div>
-                    ))}
-                </div>
-            </section>
-
-            {/* Sample Card */}
-            <section className="py-8 space-y-6 border-t border-border">
-                <h2 className="text-heading-2-xl text-foreground">Sample Market Card</h2>
-
-                <div className="max-w-md rounded-xl bg-card border border-border p-5 space-y-4">
-                    <div className="flex items-center gap-2">
-                        <span className="text-label text-primary">Finance</span>
-                        <span className="text-caption">· chance</span>
-                    </div>
-                    <h3 className="text-heading-2 text-foreground">
-                        Fed rate cut in March 2026?
-                    </h3>
-                    <div className="flex items-baseline gap-2">
-                        <span className="text-hero text-primary">45%</span>
-                        <span className="text-caption text-success">+2.1%</span>
-                    </div>
-                    <div className="flex gap-3">
-                        <button className="flex-1 py-2 rounded-md bg-primary text-primary-foreground text-btn">
-                            Yes 45¢
-                        </button>
-                        <button className="flex-1 py-2 rounded-md bg-destructive text-destructive-foreground text-btn">
-                            No 55¢
-                        </button>
-                    </div>
-                    <div className="flex gap-4 text-caption">
-                        <span>$6.3M Vol</span>
-                        <span>5,621 traders</span>
-                        <span>Mar 15</span>
-                    </div>
-                </div>
-            </section>
-        </main>
+            <Footer />
+        </>
     )
 }

--- a/components/home/AllMarkets.tsx
+++ b/components/home/AllMarkets.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState } from "react"
+import { ArrowUpDown, SlidersHorizontal, LayoutGrid, List } from "lucide-react"
+import { allMarkets } from "@/lib/mock-data"
+import { MarketCard } from "./MarketCard"
+
+export function AllMarkets() {
+    const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
+    const [visibleCount, setVisibleCount] = useState(8)
+
+    const visibleMarkets = allMarkets.slice(0, visibleCount)
+
+    return (
+        <section className="space-y-5">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <h2 className="text-heading-2-xl text-foreground">
+                    All Markets
+                </h2>
+
+                <div className="flex items-center gap-3">
+                    {/* Sort */}
+                    <button className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary border border-border text-body text-muted-foreground hover:text-foreground transition-colors">
+                        <ArrowUpDown className="w-3.5 h-3.5" />
+                        <span className="text-caption">Sort by:</span>
+                        <span className="text-caption text-foreground">
+                            24h Volume
+                        </span>
+                    </button>
+
+                    {/* Filters */}
+                    <button className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary border border-border text-caption text-muted-foreground hover:text-foreground transition-colors">
+                        <SlidersHorizontal className="w-3.5 h-3.5" />
+                        Filters
+                    </button>
+
+                    {/* View Toggle */}
+                    <div className="flex items-center bg-secondary rounded-lg border border-border overflow-hidden">
+                        <button
+                            onClick={() => setViewMode("grid")}
+                            className={`p-1.5 transition-colors ${viewMode === "grid"
+                                    ? "bg-primary/15 text-primary"
+                                    : "text-muted-foreground hover:text-foreground"
+                                }`}
+                        >
+                            <LayoutGrid className="w-4 h-4" />
+                        </button>
+                        <button
+                            onClick={() => setViewMode("list")}
+                            className={`p-1.5 transition-colors ${viewMode === "list"
+                                    ? "bg-primary/15 text-primary"
+                                    : "text-muted-foreground hover:text-foreground"
+                                }`}
+                        >
+                            <List className="w-4 h-4" />
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {/* Market Grid */}
+            <div
+                className={
+                    viewMode === "grid"
+                        ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+                        : "flex flex-col gap-3"
+                }
+            >
+                {visibleMarkets.map((market) => (
+                    <MarketCard key={market.id} market={market} />
+                ))}
+            </div>
+
+            {/* Load More */}
+            {visibleCount < allMarkets.length && (
+                <div className="flex justify-center pt-4">
+                    <button
+                        onClick={() =>
+                            setVisibleCount((c) =>
+                                Math.min(c + 8, allMarkets.length)
+                            )
+                        }
+                        className="inline-flex items-center px-8 py-2.5 rounded-full border border-border text-body text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                    >
+                        Load more markets
+                    </button>
+                </div>
+            )}
+        </section>
+    )
+}

--- a/components/home/CategoryTabs.tsx
+++ b/components/home/CategoryTabs.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useState } from "react"
+import {
+    TrendingUp,
+    Sparkles,
+    Landmark,
+    Trophy,
+    Bitcoin,
+    BarChart3,
+    Cpu,
+    Music,
+    Globe,
+    CloudSun,
+} from "lucide-react"
+import { categories } from "@/lib/mock-data"
+import { cn } from "@/lib/utils"
+
+const iconMap: Record<string, React.ElementType> = {
+    TrendingUp,
+    Sparkles,
+    Landmark,
+    Trophy,
+    Bitcoin,
+    BarChart3,
+    Cpu,
+    Music,
+    Globe,
+    CloudSun,
+}
+
+export function CategoryTabs() {
+    const [activeId, setActiveId] = useState("trending")
+
+    return (
+        <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-none">
+            {categories.map((cat) => {
+                const Icon = iconMap[cat.icon]
+                const isActive = activeId === cat.id
+                return (
+                    <button
+                        key={cat.id}
+                        onClick={() => setActiveId(cat.id)}
+                        className={cn(
+                            "inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-btn whitespace-nowrap transition-all",
+                            isActive
+                                ? "bg-primary/15 text-primary border border-primary/40"
+                                : "bg-secondary text-muted-foreground border border-border hover:text-foreground hover:border-muted-foreground/30"
+                        )}
+                    >
+                        {Icon && <Icon className="w-3.5 h-3.5" />}
+                        {cat.label}
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/components/home/FeaturedHero.tsx
+++ b/components/home/FeaturedHero.tsx
@@ -1,0 +1,91 @@
+import { ArrowRight, Users, Calendar, Landmark } from "lucide-react"
+import { featuredMarket } from "@/lib/mock-data"
+
+export function FeaturedHero() {
+    const m = featuredMarket
+
+    return (
+        <div className="relative rounded-2xl bg-card border border-border overflow-hidden">
+            <div className="flex flex-col md:flex-row">
+                {/* Image */}
+                <div className="relative w-full md:w-48 h-40 md:h-auto flex-shrink-0 bg-secondary overflow-hidden">
+                    <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-primary/5" />
+                    <div className="absolute inset-0 flex items-center justify-center">
+                        <div className="w-20 h-20 rounded-xl bg-primary/20 flex items-center justify-center">
+                            <Landmark className="w-10 h-10 text-primary/60" />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 p-5 md:p-6 space-y-3">
+                    {/* Badges */}
+                    <div className="flex items-center gap-2">
+                        {m.badges.map((badge) => (
+                            <span
+                                key={badge}
+                                className={`inline-flex items-center px-2.5 py-0.5 rounded-md text-caption ${badge === "Featured"
+                                        ? "bg-primary/15 text-primary"
+                                        : "bg-warning/15 text-warning"
+                                    }`}
+                            >
+                                {badge}
+                            </span>
+                        ))}
+                    </div>
+
+                    {/* Title */}
+                    <h2 className="text-heading-2-lg text-foreground">
+                        {m.title}
+                    </h2>
+
+                    {/* Description */}
+                    <p className="text-body text-muted-foreground max-w-xl">
+                        {m.description}
+                    </p>
+
+                    {/* Stats */}
+                    <div className="flex items-center gap-4 text-caption">
+                        <span className="text-primary font-bold">{m.volume}</span>
+                        <span>Volume</span>
+                        <span className="flex items-center gap-1">
+                            <Users className="w-3 h-3" />
+                            {m.traders} traders
+                        </span>
+                        <span className="flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {m.date}
+                        </span>
+                    </div>
+
+                    {/* Chance + Buttons */}
+                    <div className="flex items-center justify-between pt-1">
+                        <div className="flex items-baseline gap-2">
+                            <span className="text-3xl font-bold text-primary">
+                                {m.chance}%
+                            </span>
+                            <span className="text-body text-muted-foreground">
+                                chance
+                            </span>
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                            <button className="inline-flex items-center px-6 py-2 rounded-lg bg-primary text-primary-foreground text-btn transition-all hover:brightness-110 active:scale-95">
+                                Buy Yes
+                            </button>
+                            <button className="inline-flex items-center px-6 py-2 rounded-lg bg-destructive text-destructive-foreground text-btn transition-all hover:brightness-110 active:scale-95">
+                                Buy No
+                            </button>
+                            <button
+                                className="p-2 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                                aria-label="View details"
+                            >
+                                <ArrowRight className="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/components/home/LiveSports.tsx
+++ b/components/home/LiveSports.tsx
@@ -1,0 +1,109 @@
+import { Users } from "lucide-react"
+import { sportsMatches } from "@/lib/mock-data"
+
+export function LiveSports() {
+    return (
+        <section className="space-y-4">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <h2 className="flex items-center gap-2 text-heading-2-lg text-foreground">
+                    <span className="relative flex h-2.5 w-2.5">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-destructive opacity-75" />
+                        <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-destructive" />
+                    </span>
+                    Live &amp; Upcoming Sports
+                </h2>
+                <button className="text-caption text-primary hover:underline">
+                    View all
+                </button>
+            </div>
+
+            {/* Cards */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {sportsMatches.map((match) => (
+                    <div
+                        key={match.id}
+                        className="rounded-xl bg-card border border-border p-4 space-y-4 hover:border-primary/30 transition-colors"
+                    >
+                        {/* League + Time */}
+                        <div className="flex items-center gap-2">
+                            <span
+                                className="text-btn text-xs px-2 py-0.5 rounded font-bold"
+                                style={{
+                                    color: match.leagueColor,
+                                    backgroundColor: `${match.leagueColor}15`,
+                                }}
+                            >
+                                {match.league}
+                            </span>
+                            {match.isLive ? (
+                                <span className="flex items-center gap-1 text-caption text-destructive">
+                                    <span className="relative flex h-1.5 w-1.5">
+                                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-destructive opacity-75" />
+                                        <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-destructive" />
+                                    </span>
+                                    {match.liveIndicator}
+                                </span>
+                            ) : (
+                                <span className="flex items-center gap-1 text-caption">
+                                    ⏱ {match.time}
+                                </span>
+                            )}
+                        </div>
+
+                        {/* Teams */}
+                        <div className="space-y-3">
+                            {match.teams.map((team) => (
+                                <div
+                                    key={team.abbreviation}
+                                    className="flex items-center justify-between"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <div className="w-6 h-6 rounded-full bg-secondary flex items-center justify-center flex-shrink-0">
+                                            <span className="text-[8px] font-bold text-muted-foreground">
+                                                {team.abbreviation.slice(0, 2)}
+                                            </span>
+                                        </div>
+                                        <span className="text-body text-foreground">
+                                            {team.name}
+                                        </span>
+                                        {team.score !== undefined && (
+                                            <span className="text-heading-3 text-foreground ml-1">
+                                                {team.score}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <span className="text-heading-3 text-foreground">
+                                        {team.odds}%
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* Bet Buttons */}
+                        <div className="grid grid-cols-3 gap-2">
+                            <button className="py-1.5 rounded-md text-btn text-xs bg-primary text-primary-foreground transition-all hover:brightness-110 active:scale-95">
+                                {match.teams[0].abbreviation}
+                            </button>
+                            <button className="py-1.5 rounded-md text-btn text-xs bg-secondary text-secondary-foreground hover:text-foreground transition-colors">
+                                Draw
+                            </button>
+                            <button className="py-1.5 rounded-md text-btn text-xs bg-secondary text-secondary-foreground hover:text-foreground transition-colors">
+                                {match.teams[1].abbreviation}
+                            </button>
+                        </div>
+
+                        {/* Footer Stats */}
+                        <div className="flex items-center justify-between text-caption">
+                            <span>{match.volume} Vol.</span>
+                            <span className="flex items-center gap-1">
+                                <Users className="w-3 h-3" />
+                                {match.traders} traders
+                            </span>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/components/home/MarketCard.tsx
+++ b/components/home/MarketCard.tsx
@@ -1,0 +1,162 @@
+import { TrendingDown, Users, MessageCircle, Calendar } from "lucide-react"
+import type { MarketCardData } from "@/lib/types"
+
+interface MarketCardProps {
+    market: MarketCardData
+}
+
+export function MarketCard({ market }: MarketCardProps) {
+    const m = market
+
+    // Multi-outcome card (like Grammys)
+    if (m.outcomes && m.outcomes.length > 0) {
+        return (
+            <div className="rounded-xl bg-card border border-border p-4 space-y-3 hover:border-primary/30 transition-colors group">
+                {/* Category */}
+                <div className="flex items-center gap-2">
+                    {m.image && (
+                        <div className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center flex-shrink-0">
+                            <span className="text-[10px] font-bold text-muted-foreground">
+                                {m.category.slice(0, 2).toUpperCase()}
+                            </span>
+                        </div>
+                    )}
+                    <div>
+                        <span
+                            className="text-caption font-bold"
+                            style={{ color: m.categoryColor }}
+                        >
+                            {m.category}
+                        </span>
+                        <h3 className="text-heading-3 text-foreground leading-tight text-sm">
+                            {m.title}
+                        </h3>
+                    </div>
+                </div>
+
+                {/* Outcomes list */}
+                <div className="space-y-2">
+                    {m.outcomes.map((outcome) => (
+                        <div
+                            key={outcome.name}
+                            className="flex items-center justify-between"
+                        >
+                            <span className="text-body text-muted-foreground text-xs truncate mr-2">
+                                {outcome.name}
+                            </span>
+                            <div className="flex items-center gap-1.5">
+                                <span className="text-heading-3 text-foreground text-xs">
+                                    {outcome.odds}%
+                                </span>
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/15 text-primary font-bold">
+                                    Yes
+                                </span>
+                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-destructive/15 text-destructive font-bold">
+                                    No
+                                </span>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Footer */}
+                <div className="flex items-center gap-3 text-caption pt-1">
+                    <span>{m.volume} Vol.</span>
+                    <span className="flex items-center gap-0.5">
+                        <Users className="w-3 h-3" />
+                        {m.traders}
+                    </span>
+                    <span className="flex items-center gap-0.5">
+                        <MessageCircle className="w-3 h-3" />
+                        {m.comments}
+                    </span>
+                    <span className="flex items-center gap-0.5 ml-auto">
+                        <Calendar className="w-3 h-3" />
+                        {m.date}
+                    </span>
+                </div>
+            </div>
+        )
+    }
+
+    // Standard binary card
+    return (
+        <div className="rounded-xl bg-card border border-border p-4 space-y-3 hover:border-primary/30 transition-colors group">
+            {/* Category + Image */}
+            <div className="flex items-start gap-3">
+                {m.image && (
+                    <div className="w-10 h-10 rounded-lg bg-secondary flex items-center justify-center flex-shrink-0">
+                        <span className="text-[10px] font-bold text-muted-foreground">
+                            {m.category.slice(0, 2).toUpperCase()}
+                        </span>
+                    </div>
+                )}
+                <div className="flex-1 min-w-0">
+                    <span
+                        className="text-caption font-bold"
+                        style={{ color: m.categoryColor }}
+                    >
+                        {m.category}
+                    </span>
+                    <h3 className="text-heading-3 text-foreground leading-snug mt-0.5">
+                        {m.title}
+                    </h3>
+                </div>
+            </div>
+
+            {/* Chance + Trend */}
+            <div className="flex items-baseline gap-2">
+                <span className="text-2xl font-bold text-primary">
+                    {m.chance}%
+                </span>
+                {m.trend && (
+                    <span
+                        className={`flex items-center gap-0.5 text-caption ${m.trendPositive ? "text-primary" : "text-destructive"
+                            }`}
+                    >
+                        <TrendingDown className="w-3 h-3" />
+                        {m.trend}
+                    </span>
+                )}
+                <span className="text-caption ml-auto">chance</span>
+            </div>
+
+            {/* Progress bar */}
+            <div className="w-full h-1 rounded-full bg-secondary overflow-hidden">
+                <div
+                    className="h-full rounded-full bg-primary transition-all"
+                    style={{ width: `${m.chance}%` }}
+                />
+            </div>
+
+            {/* Yes/No Buttons */}
+            <div className="grid grid-cols-2 gap-2">
+                <button className="py-1.5 rounded-md bg-primary text-primary-foreground text-btn text-xs transition-all hover:brightness-110 active:scale-95">
+                    Yes {m.yesPrice}
+                </button>
+                <button className="py-1.5 rounded-md bg-destructive text-destructive-foreground text-btn text-xs transition-all hover:brightness-110 active:scale-95">
+                    No {m.noPrice}
+                </button>
+            </div>
+
+            {/* Footer Stats */}
+            <div className="flex items-center gap-3 text-caption pt-1">
+                <span>{m.volume} Vol.</span>
+                <span className="flex items-center gap-0.5">
+                    <Users className="w-3 h-3" />
+                    {m.traders}
+                </span>
+                {m.comments && (
+                    <span className="flex items-center gap-0.5">
+                        <MessageCircle className="w-3 h-3" />
+                        {m.comments}
+                    </span>
+                )}
+                <span className="flex items-center gap-0.5 ml-auto">
+                    <Calendar className="w-3 h-3" />
+                    {m.date}
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link"
+
+const footerLinks = {
+    categories: [
+        { label: "Politics", href: "/category/politics" },
+        { label: "Sports", href: "/category/sports" },
+        { label: "Crypto", href: "/category/crypto" },
+        { label: "Finance", href: "/category/finance" },
+        { label: "Culture", href: "/category/culture" },
+        { label: "World", href: "/category/world" },
+        { label: "World", href: "/category/world-2" },
+        { label: "Tech", href: "/category/tech" },
+    ],
+    precast: [
+        { label: "About", href: "/about" },
+        { label: "Terms", href: "/terms" },
+        { label: "Privacy", href: "/privacy" },
+    ],
+    socials: [
+        { label: "Discord", href: "https://discord.gg/precast" },
+        { label: "Twitter", href: "https://twitter.com/precast" },
+    ],
+}
+
+export function Footer() {
+    return (
+        <footer className="border-t border-border bg-muted/40 mt-12">
+            <div className="container-app py-12">
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
+                    {/* Logo */}
+                    <div className="flex items-start">
+                        <div className="flex items-center gap-2">
+                            <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-primary">
+                                <span className="text-white text-sm font-bold">P</span>
+                            </div>
+                            <span className="text-heading-3 text-foreground">
+                                precast
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Market Categories */}
+                    <div>
+                        <h4 className="text-heading-3 text-foreground mb-4">
+                            Market Categories
+                        </h4>
+                        <div className="grid grid-cols-2 gap-2">
+                            {footerLinks.categories.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="text-body text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                    {link.label}
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Precast */}
+                    <div>
+                        <h4 className="text-heading-3 text-foreground mb-4">
+                            Precast
+                        </h4>
+                        <div className="flex flex-col gap-2">
+                            {footerLinks.precast.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="text-body text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                    {link.label}
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Socials */}
+                    <div>
+                        <h4 className="text-heading-3 text-foreground mb-4">
+                            Socials
+                        </h4>
+                        <div className="flex flex-col gap-2">
+                            {footerLinks.socials.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-body text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                    {link.label}
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+
+                {/* Copyright */}
+                <div className="mt-10 pt-6 border-t border-border text-center">
+                    <p className="text-caption">
+                        © 2026 Precast. All rights reserved.
+                    </p>
+                </div>
+            </div>
+        </footer>
+    )
+}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Search, Bell, Command } from "lucide-react"
+
+export function Navbar() {
+    return (
+        <nav className="glass sticky top-0 z-50 w-full">
+            <div className="container-app flex items-center justify-between py-3">
+                {/* Logo */}
+                <div className="flex items-center gap-2">
+                    <div className="flex items-center justify-center w-7 h-7 rounded-lg bg-primary">
+                        <span className="text-white text-sm font-bold">P</span>
+                    </div>
+                    <span className="text-heading-3 text-foreground">precast</span>
+                </div>
+
+                {/* Search Bar */}
+                <div className="hidden md:flex items-center gap-2 bg-card border border-border rounded-lg px-4 py-2 w-full max-w-md mx-8">
+                    <Search className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-body text-muted-foreground flex-1">
+                        Search markets...
+                    </span>
+                    <div className="flex items-center gap-0.5 px-1.5 py-0.5 bg-secondary rounded border border-border">
+                        <Command className="w-3 h-3 text-muted-foreground" />
+                        <span className="text-kbd-sm text-muted-foreground">K</span>
+                    </div>
+                </div>
+
+                {/* Right Actions */}
+                <div className="flex items-center gap-3">
+                    <button
+                        className="relative p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                        aria-label="Notifications"
+                    >
+                        <Bell className="w-5 h-5" />
+                    </button>
+                    <button className="inline-flex items-center px-5 py-2 rounded-full border border-border text-foreground text-btn transition-colors hover:bg-secondary">
+                        Sign In
+                    </button>
+                </div>
+            </div>
+        </nav>
+    )
+}

--- a/components/layout/TrendingTicker.tsx
+++ b/components/layout/TrendingTicker.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { TrendingUp } from "lucide-react"
+import { trendingItems } from "@/lib/mock-data"
+
+export function TrendingTicker() {
+    // Double the items for seamless loop
+    const items = [...trendingItems, ...trendingItems]
+
+    return (
+        <div className="relative w-full overflow-hidden border-b border-border bg-background py-2.5">
+            {/* Fade edges */}
+            <div className="pointer-events-none absolute left-0 top-0 z-10 h-full w-20 bg-gradient-to-r from-background to-transparent" />
+            <div className="pointer-events-none absolute right-0 top-0 z-10 h-full w-20 bg-gradient-to-l from-background to-transparent" />
+
+            <div className="ticker-track flex items-center gap-8 whitespace-nowrap">
+                {items.map((item, i) => (
+                    <div
+                        key={`${item.label}-${i}`}
+                        className="flex items-center gap-4"
+                    >
+                        {i % trendingItems.length === 0 && (
+                            <span className="flex items-center gap-1.5 text-caption text-muted-foreground">
+                                <TrendingUp className="w-3.5 h-3.5 text-primary" />
+                                Trending
+                            </span>
+                        )}
+                        <span className="flex items-center gap-2">
+                            <span className="text-body-medium text-foreground">
+                                {item.label}
+                            </span>
+                            <span
+                                className={`text-caption ${item.positive
+                                        ? "text-primary"
+                                        : "text-destructive"
+                                    }`}
+                            >
+                                {item.change}
+                            </span>
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/hooks/useMarket.ts
+++ b/hooks/useMarket.ts
@@ -1,7 +1,7 @@
 import { useReadContract } from "wagmi"
 import { CONTRACT_ADDRESS } from "@/lib/constants"
 import LMSRABI from "@/lib/LMSRABI.json"
-import { Market } from "@/lib/mock-data"
+import { Market } from "@/lib/types"
 import { formatEther } from "viem"
 import { useEffect, useState } from "react"
 import { fetchIPFSMetadata, getIPFSUrl } from "@/lib/ipfs"

--- a/hooks/useMarkets.ts
+++ b/hooks/useMarkets.ts
@@ -3,7 +3,7 @@
 import { useReadContract, useReadContracts } from "wagmi"
 import { CONTRACT_ADDRESS } from "@/lib/constants"
 import LMSRABI from "@/lib/LMSRABI.json"
-import { Market } from "@/lib/mock-data"
+import { Market } from "@/lib/types"
 import { formatEther } from "viem"
 import { useEffect, useState } from "react"
 import { fetchIPFSMetadata, getIPFSUrl } from "@/lib/ipfs"
@@ -123,11 +123,11 @@ export function useMarkets() {
         const metadata = metadataMap[cId]
         console.log('Metadata', metadata)
         if (metadata?.image) {
-            if(metadata?.imageSource === "cloudinary") {
+            if (metadata?.imageSource === "cloudinary") {
                 imageUrl = metadata.image;
             } else {
 
-             imageUrl = getIPFSUrl(metadata.image)
+                imageUrl = getIPFSUrl(metadata.image)
             }
         } else if (cId && cId.includes("TestImageCid")) {
             imageUrl = "/super-bowl-atmosphere.png"

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,160 +1,216 @@
-export interface Outcome {
-  name: string
-  probability: number
+import type {
+  TrendingItem,
+  FeaturedMarket,
+  SportMatch,
+  MarketCardData,
+  Category,
+} from "./types"
+
+/* ── Trending Ticker ───────────────────────────────── */
+export const trendingItems: TrendingItem[] = [
+  { label: "Super Bowl", change: "+12%", positive: true },
+  { label: "Fed Rate", change: "+8%", positive: true },
+  { label: "Trump", change: "+5%", positive: true },
+  { label: "Bitcoin $100k", change: "+3%", positive: true },
+  { label: "Grammys", change: "+2%", positive: true },
+]
+
+/* ── Category Tabs ─────────────────────────────────── */
+export const categories: Category[] = [
+  { id: "trending", label: "Trending", icon: "TrendingUp", active: true },
+  { id: "new", label: "New", icon: "Sparkles" },
+  { id: "politics", label: "Politics", icon: "Landmark" },
+  { id: "sports", label: "Sports", icon: "Trophy" },
+  { id: "crypto", label: "Crypto", icon: "Bitcoin" },
+  { id: "finance", label: "Finance", icon: "BarChart3" },
+  { id: "tech", label: "Tech", icon: "Cpu" },
+  { id: "culture", label: "Culture", icon: "Music" },
+  { id: "world", label: "World", icon: "Globe" },
+  { id: "weather", label: "Weather", icon: "CloudSun" },
+]
+
+/* ── Featured Hero Market ──────────────────────────── */
+export const featuredMarket: FeaturedMarket = {
+  id: "featured-1",
+  image: "/featured-government.jpg",
+  badges: ["Featured", "🔥 Hot"],
+  title: "US Government shutdown by February?",
+  description:
+    "Will the US federal government experience a partial or full shutdown before the end of February 2026?",
+  volume: "$45.2M",
+  traders: "12,453",
+  date: "Feb 28, 2026",
+  chance: 72,
 }
 
-export interface Market {
-  id: string
-  title: string
-  image: string
-  type: "binary"
-  outcomes: Outcome[]
-  volume: string
-  tag?: string
-  startTime?: number
-  endTime?: number
-  resolved?: boolean
-  yesWon?: boolean
-  description?: string
-  resolutionSource?: string
-  startDate?: string
-  endDate?: string
-  category?: string
-  isExpired?: boolean
-}
+/* ── Live & Upcoming Sports ────────────────────────── */
+export const sportsMatches: SportMatch[] = [
+  {
+    id: "sport-1",
+    league: "NFL",
+    leagueColor: "#1E993B",
+    time: "Feb 8, 6:30 PM",
+    teams: [
+      { name: "Seattle Seahawks", abbreviation: "SEA", odds: 69 },
+      { name: "New England Patriots", abbreviation: "NE", odds: 31 },
+    ],
+    volume: "$5.2M",
+    traders: "374",
+    isLive: false,
+  },
+  {
+    id: "sport-2",
+    league: "NBA",
+    leagueColor: "#EF4343",
+    liveIndicator: "3Q 4:23",
+    teams: [
+      { name: "LA Clippers", abbreviation: "LAC", score: 89, odds: 56 },
+      { name: "Denver Nuggets", abbreviation: "DEN", score: 82, odds: 44 },
+    ],
+    volume: "$3.1M",
+    traders: "401",
+    isLive: true,
+  },
+  {
+    id: "sport-3",
+    league: "Ligue 1",
+    leagueColor: "#6495ED",
+    liveIndicator: "2H 81'",
+    teams: [
+      { name: "Racing Club de Lens", abbreviation: "LENS", score: 1, odds: 87 },
+      { name: "Le Havre AC", abbreviation: "HAC", score: 0, odds: 13 },
+    ],
+    volume: "$890K",
+    traders: "273",
+    isLive: true,
+  },
+]
 
-export const mockMarkets: Market[] = [
+/* ── All Markets Grid ──────────────────────────────── */
+export const allMarkets: MarketCardData[] = [
   {
-    id: "1",
-    title: "Khamenei out as Supreme Leader of Iran by January 31?",
-    image: "/iran.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 18 },
-      { name: "No", probability: 82 },
-    ],
-    volume: "6",
+    id: "market-1",
+    category: "Finance",
+    categoryColor: "#1E993B",
+    title: "Fed rate cut in March 2026?",
+    chance: 45,
+    trend: "2.1%",
+    trendPositive: false,
+    yesPrice: "45¢",
+    noPrice: "55¢",
+    volume: "$8.3M",
+    traders: "5621",
+    comments: "156",
+    date: "Mar 15",
   },
   {
-    id: "2",
-    title: "Will Trump acquire Greenland before 2027?",
-    image: "/greenland.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 16 },
-      { name: "No", probability: 84 },
-    ],
-    volume: "4",
+    id: "market-2",
+    category: "Finance",
+    categoryColor: "#1E993B",
+    title: "Fed rate cut in March 2026?",
+    chance: 45,
+    trend: "2.1%",
+    trendPositive: false,
+    yesPrice: "45¢",
+    noPrice: "55¢",
+    volume: "$8.3M",
+    traders: "5621",
+    comments: "156",
+    date: "Mar 15",
   },
   {
-    id: "3",
-    title: "Israel strikes Iran by January 31, 2026?",
-    image: "/israel-iran.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 32 },
-      { name: "No", probability: 68 },
-    ],
-    volume: "5",
+    id: "market-3",
+    category: "Tech",
+    categoryColor: "#6495ED",
+    title: "OpenAI releases GPT-5 by Q2 2026?",
+    chance: 67,
+    trend: "8.4%",
+    trendPositive: false,
+    yesPrice: "67¢",
+    noPrice: "33¢",
+    volume: "$5.8M",
+    traders: "9234",
+    comments: "567",
+    date: "Jun 30",
   },
   {
-    id: "4",
-    title: "Elon Musk # tweets January 2 - January 9, 2026?",
-    image: "/elon-musk-portrait.png",
-    type: "binary",
+    id: "market-4",
+    category: "Culture",
+    categoryColor: "#EAE243",
+    title: "Grammys 2026: Song of the Year Winner",
+    chance: 45,
+    trend: "",
+    trendPositive: true,
+    yesPrice: "",
+    noPrice: "",
+    volume: "$2.1M",
+    traders: "3421",
+    comments: "89",
+    date: "Feb 2",
     outcomes: [
-      { name: "Yes", probability: 70 },
-      { name: "No", probability: 30 },
+      { name: "Beyoncé - Texas Hold '...", odds: 45 },
+      { name: "Taylor Swift - Fortnight", odds: 28 },
+      { name: "Sabrina Carpenter - Esp...", odds: 18 },
     ],
-    volume: "16",
   },
   {
-    id: "5",
-    title: "US strikes Iran by...?",
-    image: "/us-iran.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 6 },
-      { name: "No", probability: 94 },
-    ],
-    volume: "4",
+    id: "market-5",
+    category: "Politics",
+    categoryColor: "#EF4343",
+    title: "Will Elon Musk step down as DOGE lead?",
+    chance: 23,
+    trend: "1.8%",
+    trendPositive: false,
+    yesPrice: "23¢",
+    noPrice: "77¢",
+    volume: "$15.7M",
+    traders: "15678",
+    comments: "892",
+    date: "Jun 1",
   },
   {
-    id: "6",
-    title: "Super Bowl Champion 2026",
-    image: "/super-bowl-atmosphere.png",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 19 },
-      { name: "No", probability: 81 },
-    ],
-    volume: "661",
+    id: "market-6",
+    category: "Finance",
+    categoryColor: "#1E993B",
+    title: "Tesla stock above $500 by March?",
+    chance: 41,
+    trend: "4.5%",
+    trendPositive: false,
+    yesPrice: "41¢",
+    noPrice: "59¢",
+    volume: "$9.4M",
+    traders: "7234",
+    comments: "345",
+    date: "Mar 31",
   },
   {
-    id: "7",
-    title: "Will Venezuelan regime fall before 2027?",
-    image: "/venezuela.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 40 },
-      { name: "No", probability: 60 },
-    ],
-    volume: "2",
+    id: "market-7",
+    category: "World",
+    categoryColor: "#6495ED",
+    title: "Ukraine ceasefire agreement by April?",
+    chance: 28,
+    trend: "3.2%",
+    trendPositive: false,
+    yesPrice: "28¢",
+    noPrice: "72¢",
+    volume: "$22.1M",
+    traders: "18923",
+    comments: "1234",
+    date: "Apr 30",
   },
   {
-    id: "8",
-    title: "Portugal Presidential Election",
-    image: "/portugal-election.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 42 },
-      { name: "No", probability: 58 },
-    ],
-    volume: "94",
-  },
-  {
-    id: "9",
-    title: "Presidential Election Winner 2028",
-    image: "/2028-election.jpg",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 28 },
-      { name: "No", probability: 72 },
-    ],
-    volume: "178",
-  },
-  {
-    id: "10",
-    title: "S&P 500 (SPX) Up or Down on January 9?",
-    image: "/stock-market-analysis.png",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 66 },
-      { name: "No", probability: 34 },
-    ],
-    volume: "14",
-    tag: "repeat-3",
-  },
-  {
-    id: "11",
-    title: "Bitcoin above ___ on January 9?",
-    image: "/bitcoin-concept.png",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 50 },
-      { name: "No", probability: 50 },
-    ],
-    volume: "4",
-  },
-  {
-    id: "12",
-    title: "Will Silver (SI) hit__ by end of January?",
-    image: "/silver-commodity.png",
-    type: "binary",
-    outcomes: [
-      { name: "Yes", probability: 7 },
-      { name: "No", probability: 93 },
-    ],
-    volume: "2",
+    id: "market-8",
+    category: "Tech",
+    categoryColor: "#6495ED",
+    title: "Apple announces AR glasses in 2026?",
+    chance: 56,
+    trend: "0.8%",
+    trendPositive: false,
+    yesPrice: "56¢",
+    noPrice: "44¢",
+    volume: "$4.2M",
+    traders: "4567",
+    comments: "234",
+    date: "Dec 31",
   },
 ]

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,3 +21,69 @@ export interface Market {
     endDate?: string
     category?: string
 }
+
+/* ── Homepage-specific types ─────────────────────── */
+
+export interface TrendingItem {
+    label: string
+    change: string
+    positive: boolean
+}
+
+export interface Category {
+    id: string
+    label: string
+    icon: string // Lucide icon name
+    active?: boolean
+}
+
+export interface FeaturedMarket {
+    id: string
+    image: string
+    badges: string[]
+    title: string
+    description: string
+    volume: string
+    traders: string
+    date: string
+    chance: number
+}
+
+export interface SportTeam {
+    name: string
+    abbreviation: string
+    logo?: string
+    score?: number
+    odds: number
+}
+
+export interface SportMatch {
+    id: string
+    league: string
+    leagueColor: string
+    time?: string
+    liveIndicator?: string
+    teams: SportTeam[]
+    volume: string
+    traders: string
+    isLive: boolean
+}
+
+export interface MarketCardData {
+    id: string
+    category: string
+    categoryColor: string
+    title: string
+    image?: string
+    chance: number
+    trend: string
+    trendPositive: boolean
+    yesPrice: string
+    noPrice: string
+    volume: string
+    traders: string
+    comments?: string
+    date: string
+    // For multi-outcome cards
+    outcomes?: { name: string; odds: number; hasYes?: boolean; hasNo?: boolean }[]
+}


### PR DESCRIPTION
## Summary

This PR implements the complete first screen of the Precast prediction market homepage, matching the Figma design. Replaces the previous design-system demo page with a fully-composed homepage.

## Design Fidelity
- Dark theme with existing design system tokens
- Green primary (#1E993B) / Red destructive (#EF4343) palette
- Inter font with Figma-verified typography scale
- Responsive grid layouts (1→2→3→4 columns)
- Micro-animations: ticker scroll, ping indicators, hover effects, active scale

_**NOTE:** This is not a pixel-perfect design in comparison with the Figma design_